### PR TITLE
Add new feature to link notes in both directions with 1 command

### DIFF
--- a/src/main/java/seedu/zettel/Parser.java
+++ b/src/main/java/seedu/zettel/Parser.java
@@ -7,14 +7,15 @@ import seedu.zettel.commands.DeleteNoteCommand;
 import seedu.zettel.commands.ExitCommand;
 import seedu.zettel.commands.FindNoteCommand;
 import seedu.zettel.commands.InitCommand;
+import seedu.zettel.commands.LinkBothNotesCommand;
 import seedu.zettel.commands.LinkNotesCommand;
 import seedu.zettel.commands.ListLinkedNotesCommand;
-import seedu.zettel.commands.UnlinkNotesCommand;
 import seedu.zettel.commands.ListNoteCommand;
 import seedu.zettel.commands.NewNoteCommand;
 import seedu.zettel.commands.NewTagCommand;
 import seedu.zettel.commands.PinNoteCommand;
 import seedu.zettel.commands.TagNoteCommand;
+import seedu.zettel.commands.UnlinkNotesCommand;
 import seedu.zettel.exceptions.EmptyDescriptionException;
 import seedu.zettel.exceptions.InvalidFormatException;
 import seedu.zettel.exceptions.InvalidInputException;
@@ -40,6 +41,8 @@ public class Parser {
             + " <SOURCE_NOTE_ID> <TARGET_NOTE_ID>";
     private static final String UNLINK_NOTES_FORMAT = "Unlink notes command format should be: unlink" 
             + " <SOURCE_NOTE_ID> <TARGET_NOTE_ID>";
+    private static final String LINK_BOTH_NOTES_FORMAT = "Linking both notes command format should be: link-both" 
+            + " <NOTE_ID_1> <NOTE_ID_2>";
     private static final String NOTE_EMPTY = "Note title cannot be empty!";
     private static final String TAG_EMPTY = "Tag cannot be empty!";
     private static final String ID_EMPTY = "Please specify a Note ID to ";
@@ -81,6 +84,7 @@ public class Parser {
         case "tag" -> parseTagCommand(inputs);
         case "link" -> parseLinkNotesCommand(inputs);
         case "unlink" -> parseUnlinkNotesCommand(inputs);
+        case "link-both" -> parseLinkBothNotesCommand(inputs);
         default -> throw new InvalidInputException(command);
         };
     }
@@ -392,12 +396,30 @@ public class Parser {
     private static Command parseUnlinkNotesCommand(String[] inputs) throws ZettelException {
         // Expected format: unlink <SOURCE_NOTE_ID> <TARGET_NOTE_ID>
         if (inputs.length != 3) {
-            throw new InvalidFormatException(LINK_NOTES_FORMAT);
+            throw new InvalidFormatException(UNLINK_NOTES_FORMAT);
         }
 
         String sourceNoteId = parseNoteId(inputs[1], "unlink to");
         String targetNoteId = parseNoteId(inputs[2], "unlink to");
 
         return new UnlinkNotesCommand(sourceNoteId, targetNoteId);
+    }
+
+    /**
+     * Parses a link-both notes command to create a bidirectional link between two notes.
+     * @param inputs The tokenized user input split by spaces.
+     * @return A LinkBothNotesCommand object with the note IDs to link.
+     * @throws ZettelException If the format is invalid or parameters are missing.
+     */
+    private static Command parseLinkBothNotesCommand(String[] inputs) throws ZettelException {
+        // Expected format: link-both <note_ID_1> <note_ID_2>
+        if (inputs.length != 3) {
+            throw new InvalidFormatException(LINK_BOTH_NOTES_FORMAT);
+        }
+
+        String sourceNoteId = parseNoteId(inputs[1], "link in both directions");
+        String targetNoteId = parseNoteId(inputs[2], "link in both directions");
+
+        return new LinkBothNotesCommand(sourceNoteId, targetNoteId);
     }
 }

--- a/src/main/java/seedu/zettel/UI.java
+++ b/src/main/java/seedu/zettel/UI.java
@@ -225,4 +225,8 @@ public class UI {
     public void showNotesUnlinked(String sourceNoteId, String targetNoteId) {
         System.out.println(" The link from note #" + sourceNoteId + " to note #" + targetNoteId + " has been removed.");
     }
+
+    public void showSuccessfulDoubleLinking(String sourceTitle, String targetTitle) {
+        System.out.println(" Notes '" + sourceTitle + "' and '" + targetTitle + "' are now linked in both directions.");
+    }
 }

--- a/src/main/java/seedu/zettel/commands/LinkBothNotesCommand.java
+++ b/src/main/java/seedu/zettel/commands/LinkBothNotesCommand.java
@@ -1,0 +1,115 @@
+package seedu.zettel.commands;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import seedu.zettel.Note;
+import seedu.zettel.UI;
+import seedu.zettel.exceptions.InvalidNoteIdException;
+import seedu.zettel.exceptions.NoNotesException;
+import seedu.zettel.exceptions.NoteSelfLinkException;
+import seedu.zettel.exceptions.NotesAlreadyLinkedException;
+import seedu.zettel.storage.Storage;
+
+/**
+ * Represents a command to create a bidirectional link between two notes.
+ * This command creates links in both directions, meaning both notes will have
+ * outgoing and incoming links to each other, allowing navigation in either direction.
+ */
+public class LinkBothNotesCommand extends Command {
+
+    private final String sourceNoteId;
+    private final String targetNoteId;
+
+    /**
+     * Constructs a LinkBothNotesCommand for linking two notes by their IDs in both directions.
+     *
+     * @param sourceNoteId The ID of the first note to link.
+     * @param targetNoteId The ID of the second note to link.
+     */
+    public LinkBothNotesCommand(String sourceNoteId, String targetNoteId) {
+        this.sourceNoteId = sourceNoteId;
+        this.targetNoteId = targetNoteId;
+    }
+
+    /**
+     * Executes the bidirectional link command by creating links between the two notes in both directions.
+     * Performs multiple validations before linking:
+     * 1. Checks if the notes list is empty
+     * 2. Verifies both notes exist in the notes list
+     * 3. Checks for self-link attempts
+     * 4. Verifies a bidirectional link doesn't already exist
+     * 
+     * If a unidirectional link already exists, only the missing direction will be added.
+     *
+     * @param notes The list of all notes in the system.
+     * @param tags The list of all tags in the system (unused in this command).
+     * @param ui The UI object to display messages to the user.
+     * @param storage The storage object to persist changes (unused in this command).
+     * @throws NoNotesException If the notes list is empty.
+     * @throws InvalidNoteIdException If either note does not exist.
+     * @throws NoteSelfLinkException If attempting to link a note to itself.
+     * @throws NotesAlreadyLinkedException If a bidirectional link already exists between the notes.
+     */
+    @Override
+    public void execute(ArrayList<Note> notes, List<String> tags, UI ui, Storage storage) throws 
+            NoNotesException, InvalidNoteIdException, NotesAlreadyLinkedException,
+            NoteSelfLinkException {
+
+        // If no notes at all in the list, throw an exception
+        if (notes.isEmpty()) {
+            throw new NoNotesException("You have no notes to link.");
+        }
+
+        // Try to find both notes
+        Optional<Note> sourceNote = notes.stream()
+                .filter(n -> n.getId().equals(sourceNoteId))
+                .findFirst();
+        if (sourceNote.isEmpty()) {
+            throw new InvalidNoteIdException("Note with ID '"+ sourceNoteId + "' does not exist.");
+        }
+
+        Optional<Note> targetNote = notes.stream()
+                .filter(n -> n.getId().equals(targetNoteId))
+                .findFirst();
+        if (targetNote.isEmpty()) {
+            throw new InvalidNoteIdException("Note with ID '"+ targetNoteId + "' does not exist.");
+        }
+
+        // Check if attempting to link a note to itself
+        if (sourceNoteId.equals(targetNoteId)) {
+            throw new NoteSelfLinkException("Cannot link a note to itself. Note ID: '" + sourceNoteId + "'.");
+        }
+        
+        // Check if two-way link already exists
+        if (sourceNote.get().isLinkedTo(targetNoteId) && targetNote.get().isLinkedTo(sourceNoteId)) {
+            throw new NotesAlreadyLinkedException("Note with ID '" + sourceNoteId
+                    + "' already links in both directions to note with ID '" + targetNoteId + "'.");
+        }
+        
+
+        // Create the two-way link
+        // If a partial link already exists, only add the missing direction(s)
+        // to prevent duplicates
+        
+        // Add links from source to target if not already present
+        if (!sourceNote.get().isLinkedTo(targetNoteId)) {
+            sourceNote.get().addOutgoingLink(targetNoteId);
+        }
+        if (!sourceNote.get().isLinkedBy(targetNoteId)) {
+            sourceNote.get().addIncomingLink(targetNoteId);
+        }
+
+        // Add links from target to source if not already present
+        if (!targetNote.get().isLinkedTo(sourceNoteId)) {
+            targetNote.get().addOutgoingLink(sourceNoteId);
+        }
+        if (!targetNote.get().isLinkedBy(sourceNoteId)) {
+            targetNote.get().addIncomingLink(sourceNoteId);
+        }
+
+        ui.showSuccessfulDoubleLinking(sourceNote.get().getTitle(), targetNote.get().getTitle());
+    }
+
+}

--- a/src/main/java/seedu/zettel/commands/UnlinkNotesCommand.java
+++ b/src/main/java/seedu/zettel/commands/UnlinkNotesCommand.java
@@ -60,13 +60,7 @@ public class UnlinkNotesCommand extends Command {
             throw new NoNotesException("You have no notes to unlink.");
         }
 
-        // Validation 2: Check for self-unlink attempt (fail fast)
-        if (sourceNoteId.equals(targetNoteId)) {
-            throw new NoteSelfLinkException("Cannot unlink a note from itself. Note ID: '" 
-                    + sourceNoteId + "'.");
-        }
-
-        // Validation 3: Try to find both notes
+        // Validation 2: Try to find both notes
         Optional<Note> sourceNote = notes.stream()
                 .filter(n -> n.getId().equals(sourceNoteId))
                 .findFirst();
@@ -79,6 +73,12 @@ public class UnlinkNotesCommand extends Command {
                 .findFirst();
         if (targetNote.isEmpty()) {
             throw new InvalidNoteIdException("Note with ID '"+ targetNoteId + "' does not exist.");
+        }
+
+        // Validation 3: Check for self-unlink attempt (fail fast)
+        if (sourceNoteId.equals(targetNoteId)) {
+            throw new NoteSelfLinkException("Cannot unlink a note from itself. Note ID: '" 
+                    + sourceNoteId + "'.");
         }
 
         Note srcNote = sourceNote.get();

--- a/src/test/java/seedu/zettel/commands/LinkBothNotesCommandTest.java
+++ b/src/test/java/seedu/zettel/commands/LinkBothNotesCommandTest.java
@@ -1,0 +1,324 @@
+package seedu.zettel.commands;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import seedu.zettel.Note;
+import seedu.zettel.UI;
+import seedu.zettel.exceptions.InvalidNoteIdException;
+import seedu.zettel.exceptions.NoNotesException;
+import seedu.zettel.exceptions.NoteSelfLinkException;
+import seedu.zettel.exceptions.NotesAlreadyLinkedException;
+import seedu.zettel.exceptions.ZettelException;
+import seedu.zettel.storage.Storage;
+
+public class LinkBothNotesCommandTest {
+    @TempDir
+    Path tempDir;
+
+    private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    private final PrintStream originalOutputStream = System.out;
+    private ArrayList<Note> notes;
+    private UI ui;
+    private Storage storage;
+    private List<String> tags;
+
+    @BeforeEach
+    void setUp() {
+        System.setOut(new PrintStream(outputStream));
+        notes = new ArrayList<>();
+        tags = new ArrayList<>();
+        ui = new UI();
+        storage = new Storage(tempDir.toString());
+        storage.init();
+
+        // Create three sample notes for linking
+        Note note1 = new Note("abcd1234", "First Note", "First_Note.txt",
+                "Body of first note", Instant.now(), Instant.now());
+        Note note2 = new Note("ef567890", "Second Note", "Second_Note.txt",
+                "Body of second note", Instant.now(), Instant.now());
+        Note note3 = new Note("12345678", "Third Note", "Third_Note.txt",
+                "Body of third note", Instant.now(), Instant.now());
+
+        notes.add(note1);
+        notes.add(note2);
+        notes.add(note3);
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.setOut(originalOutputStream);
+    }
+
+    // ==================== Exception Tests ====================
+
+    @Test
+    void execute_emptyNotesList_throwsNoNotesException() {
+        ArrayList<Note> emptyNotes = new ArrayList<>();
+        LinkBothNotesCommand command = new LinkBothNotesCommand("abcd1234", "ef567890");
+
+        NoNotesException exception = assertThrows(NoNotesException.class, () -> {
+            command.execute(emptyNotes, tags, ui, storage);
+        });
+
+        assertEquals("You have no notes to link.", exception.getMessage());
+    }
+
+    @Test
+    void execute_selfLink_throwsNoteSelfLinkException() {
+        LinkBothNotesCommand command = new LinkBothNotesCommand("abcd1234", "abcd1234");
+
+        NoteSelfLinkException exception = assertThrows(NoteSelfLinkException.class, () -> {
+            command.execute(notes, tags, ui, storage);
+        });
+
+        assertEquals("Cannot link a note to itself. Note ID: 'abcd1234'.", exception.getMessage());
+    }
+
+    @Test
+    void execute_sourceNoteNotFound_throwsInvalidNoteIdException() {
+        LinkBothNotesCommand command = new LinkBothNotesCommand("99999999", "ef567890");
+
+        InvalidNoteIdException exception = assertThrows(InvalidNoteIdException.class, () -> {
+            command.execute(notes, tags, ui, storage);
+        });
+
+        assertEquals("Invalid Note ID! Note with ID '99999999' does not exist.", exception.getMessage());
+    }
+
+    @Test
+    void execute_targetNoteNotFound_throwsInvalidNoteIdException() {
+        LinkBothNotesCommand command = new LinkBothNotesCommand("abcd1234", "99999999");
+
+        InvalidNoteIdException exception = assertThrows(InvalidNoteIdException.class, () -> {
+            command.execute(notes, tags, ui, storage);
+        });
+
+        assertEquals("Invalid Note ID! Note with ID '99999999' does not exist.", exception.getMessage());
+    }
+
+    @Test
+    void execute_bothNotesNotFound_throwsInvalidNoteIdException() {
+        LinkBothNotesCommand command = new LinkBothNotesCommand("99999999", "88888888");
+
+        InvalidNoteIdException exception = assertThrows(InvalidNoteIdException.class, () -> {
+            command.execute(notes, tags, ui, storage);
+        });
+
+        // Should fail on the first note ID check
+        assertEquals("Invalid Note ID! Note with ID '99999999' does not exist.", exception.getMessage());
+    }
+
+    @Test
+    void execute_bidirectionalLinkAlreadyExists_throwsNotesAlreadyLinkedException() throws ZettelException {
+        Note note1 = notes.get(0);
+        Note note2 = notes.get(1);
+
+        // Manually create a bidirectional link
+        note1.addOutgoingLink("ef567890");
+        note1.addIncomingLink("ef567890");
+        note2.addOutgoingLink("abcd1234");
+        note2.addIncomingLink("abcd1234");
+
+        // Try to link them again
+        LinkBothNotesCommand command = new LinkBothNotesCommand("abcd1234", "ef567890");
+
+        NotesAlreadyLinkedException exception = assertThrows(NotesAlreadyLinkedException.class, () -> {
+            command.execute(notes, tags, ui, storage);
+        });
+
+        assertEquals("Note with ID 'abcd1234' already links in both directions to note with ID 'ef567890'.",
+                exception.getMessage());
+    }
+
+    // ==================== Happy Path Tests ====================
+
+    @Test
+    void execute_successfulBidirectionalLink_createsLinksBothDirections() throws ZettelException {
+        LinkBothNotesCommand command = new LinkBothNotesCommand("abcd1234", "ef567890");
+        command.execute(notes, tags, ui, storage);
+
+        Note note1 = notes.get(0); // abcd1234
+        Note note2 = notes.get(1); // ef567890
+
+        // Verify bidirectional links exist
+        assertTrue(note1.isLinkedTo("ef567890"), "Note1 should have Note2 in outgoingLinks");
+        assertTrue(note1.isLinkedBy("ef567890"), "Note1 should have Note2 in incomingLinks");
+        assertTrue(note2.isLinkedTo("abcd1234"), "Note2 should have Note1 in outgoingLinks");
+        assertTrue(note2.isLinkedBy("abcd1234"), "Note2 should have Note1 in incomingLinks");
+
+        // Verify UI message
+        String output = outputStream.toString();
+        assertTrue(output.contains("Notes 'First Note' and 'Second Note' are now linked in both directions"));
+    }
+
+    @Test
+    void execute_reverseOrderBidirectionalLink_createsLinksBothDirections() throws ZettelException {
+        // Link in reverse order: ef567890 ↔ abcd1234
+        LinkBothNotesCommand command = new LinkBothNotesCommand("ef567890", "abcd1234");
+        command.execute(notes, tags, ui, storage);
+
+        Note note1 = notes.get(0); // abcd1234
+        Note note2 = notes.get(1); // ef567890
+
+        // Verify bidirectional links exist
+        assertTrue(note1.isLinkedTo("ef567890"), "Note1 should have Note2 in outgoingLinks");
+        assertTrue(note1.isLinkedBy("ef567890"), "Note1 should have Note2 in incomingLinks");
+        assertTrue(note2.isLinkedTo("abcd1234"), "Note2 should have Note1 in outgoingLinks");
+        assertTrue(note2.isLinkedBy("abcd1234"), "Note2 should have Note1 in incomingLinks");
+
+        // Verify UI message
+        String output = outputStream.toString();
+        assertTrue(output.contains("Notes 'Second Note' and 'First Note' are now linked in both directions"));
+    }
+
+    @Test
+    void execute_unidirectionalLinkExists_addsOnlyMissingDirection() throws ZettelException {
+        Note note1 = notes.get(0);
+        Note note2 = notes.get(1);
+
+        // Create only a unidirectional link: note1 → note2 (but not note2 → note1)
+        note1.addOutgoingLink("ef567890");
+        note2.addIncomingLink("abcd1234");
+
+        // Verify unidirectional link exists
+        assertTrue(note1.isLinkedTo("ef567890"));
+        assertFalse(note2.isLinkedTo("abcd1234"));
+
+        // Execute bidirectional link command
+        LinkBothNotesCommand command = new LinkBothNotesCommand("abcd1234", "ef567890");
+        command.execute(notes, tags, ui, storage);
+
+        // Verify now bidirectional
+        assertTrue(note1.isLinkedTo("ef567890"));
+        assertTrue(note1.isLinkedBy("ef567890"));
+        assertTrue(note2.isLinkedTo("abcd1234"));
+        assertTrue(note2.isLinkedBy("abcd1234"));
+    }
+
+    @Test
+    void execute_reversUnidirectionalLinkExists_addsOnlyMissingDirection() throws ZettelException {
+        Note note1 = notes.get(0);
+        Note note2 = notes.get(1);
+
+        // Create only a reverse unidirectional link: note2 → note1 (but not note1 → note2)
+        note2.addOutgoingLink("abcd1234");
+        note1.addIncomingLink("ef567890");
+
+        // Verify unidirectional link exists
+        assertFalse(note1.isLinkedTo("ef567890"));
+        assertTrue(note2.isLinkedTo("abcd1234"));
+
+        // Execute bidirectional link command
+        LinkBothNotesCommand command = new LinkBothNotesCommand("abcd1234", "ef567890");
+        command.execute(notes, tags, ui, storage);
+
+        // Verify now bidirectional
+        assertTrue(note1.isLinkedTo("ef567890"));
+        assertTrue(note1.isLinkedBy("ef567890"));
+        assertTrue(note2.isLinkedTo("abcd1234"));
+        assertTrue(note2.isLinkedBy("abcd1234"));
+    }
+
+    @Test
+    void execute_multipleBidirectionalLinks_eachNoteHasMultipleLinks() throws ZettelException {
+        // Create bidirectional link: note1 ↔ note2
+        LinkBothNotesCommand command1 = new LinkBothNotesCommand("abcd1234", "ef567890");
+        command1.execute(notes, tags, ui, storage);
+
+        // Create bidirectional link: note1 ↔ note3
+        LinkBothNotesCommand command2 = new LinkBothNotesCommand("abcd1234", "12345678");
+        command2.execute(notes, tags, ui, storage);
+
+        Note note1 = notes.get(0); // abcd1234
+        Note note2 = notes.get(1); // ef567890
+        Note note3 = notes.get(2); // 12345678
+
+        // Verify note1 has bidirectional links to both note2 and note3
+        assertTrue(note1.isLinkedTo("ef567890"));
+        assertTrue(note1.isLinkedBy("ef567890"));
+        assertTrue(note1.isLinkedTo("12345678"));
+        assertTrue(note1.isLinkedBy("12345678"));
+
+        // Verify note2 only has bidirectional link to note1
+        assertTrue(note2.isLinkedTo("abcd1234"));
+        assertTrue(note2.isLinkedBy("abcd1234"));
+        assertFalse(note2.isLinkedTo("12345678"));
+        assertFalse(note2.isLinkedBy("12345678"));
+
+        // Verify note3 only has bidirectional link to note1
+        assertTrue(note3.isLinkedTo("abcd1234"));
+        assertTrue(note3.isLinkedBy("abcd1234"));
+        assertFalse(note3.isLinkedTo("ef567890"));
+        assertFalse(note3.isLinkedBy("ef567890"));
+    }
+
+    @Test
+    void execute_linkCountVerification_correctNumberOfLinks() throws ZettelException {
+        LinkBothNotesCommand command = new LinkBothNotesCommand("abcd1234", "ef567890");
+        command.execute(notes, tags, ui, storage);
+
+        Note note1 = notes.get(0);
+        Note note2 = notes.get(1);
+
+        // Each note should have exactly 1 outgoing and 1 incoming link
+        assertEquals(1, note1.getOutgoingLinks().size());
+        assertEquals(1, note1.getIncomingLinks().size());
+        assertEquals(1, note2.getOutgoingLinks().size());
+        assertEquals(1, note2.getIncomingLinks().size());
+    }
+
+    @Test
+    void execute_threeWayBidirectionalLinks_allNotesLinked() throws ZettelException {
+        // Create bidirectional links: note1 ↔ note2 ↔ note3
+        LinkBothNotesCommand command1 = new LinkBothNotesCommand("abcd1234", "ef567890");
+        command1.execute(notes, tags, ui, storage);
+
+        LinkBothNotesCommand command2 = new LinkBothNotesCommand("ef567890", "12345678");
+        command2.execute(notes, tags, ui, storage);
+
+        Note note1 = notes.get(0);
+        Note note2 = notes.get(1);
+        Note note3 = notes.get(2);
+
+        // Note2 should have bidirectional links to both note1 and note3
+        assertEquals(2, note2.getOutgoingLinks().size());
+        assertEquals(2, note2.getIncomingLinks().size());
+        assertTrue(note2.isLinkedTo("abcd1234"));
+        assertTrue(note2.isLinkedBy("abcd1234"));
+        assertTrue(note2.isLinkedTo("12345678"));
+        assertTrue(note2.isLinkedBy("12345678"));
+    }
+
+    @Test
+    void execute_noDuplicateLinksCreated_linksRemainsUnique() throws ZettelException {
+        Note note1 = notes.get(0);
+        Note note2 = notes.get(1);
+
+        // Create partial link manually
+        note1.addOutgoingLink("ef567890");
+
+        // Execute bidirectional link command
+        LinkBothNotesCommand command = new LinkBothNotesCommand("abcd1234", "ef567890");
+        command.execute(notes, tags, ui, storage);
+
+        // Verify no duplicates (each link set should have size 1)
+        assertEquals(1, note1.getOutgoingLinks().size());
+        assertEquals(1, note1.getIncomingLinks().size());
+        assertEquals(1, note2.getOutgoingLinks().size());
+        assertEquals(1, note2.getIncomingLinks().size());
+    }
+}


### PR DESCRIPTION
Logic: 
tries to link 2 notes in both directions with a single command, link-both <note_ID_1> <note_ID_2>.
If notes are already linked in both directions, will throw an exception.
If note is already linked in any 1 direction, will not throw an error. Will simply add the additional missing link. Will not cause an error/issue.
Just like regular linking, cannot link to itself.